### PR TITLE
Cleanup Metatype and Scr Annotations.

### DIFF
--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
@@ -1,37 +1,45 @@
 package biz.aQute.shell.sshd.config;
 
+import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 /**
  * Configuration for the Gogo SSH interface.
  */
-@ObjectClassDefinition(factoryPid = SshdConfig.PID)
-public @interface SshdConfig  {
-	String	PID				= "biz.aQute.shell.sshd";
+@ObjectClassDefinition(factoryPid = SshdConfig.PID, description = "Configuration for the Gogo SSH interface.")
+public @interface SshdConfig {
+	String PID = "biz.aQute.shell.sshd";
 
 	/**
 	 * The port to run on, by default this is {@value}
 	 */
+	@AttributeDefinition(description = "The port to run on")
 	int port() default 8062;
 
 	/**
-	 * The interface to register with. By default this is only on localhost
+	 * The interface to register with. By default this is only on 0.0.0.0
 	 */
+	@AttributeDefinition(description = "The interface to register with.")
 	String address() default "0.0.0.0";
 
 	/**
-	 * Where to store the private key. This must be in forward slashes. Default
-	 * is 'host.ser' in the bundle's directory
+	 * Where to store the private key. This must be in forward slashes. Default is
+	 * 'target/host.ser' in the bundle's directory
 	 */
+	@AttributeDefinition(description = "Where to store the private key. This must be in forward slashes.")
 	String hostkey() default "target/hostkey.ser";
 
 	/**
 	 * Support passwords.
 	 */
+	@AttributeDefinition(description = "Support passwords.")
 	boolean passwords() default false;
-	
+
 	/**
-	 * Permission for a command. The default value is {@value}, this does not allow general commands. Replace `none` with a glob expression for allowable commands  
+	 * Permission for a command. The default value is {@value}, this does not allow
+	 * general commands. Replace `none` with a glob expression for allowable
+	 * commands
 	 */
+	@AttributeDefinition(description = "Permission for a command. The default value is gogo.command:none, this does not allow general commands. Replace `none` with a glob expression for allowable commands")
 	String permission() default "gogo.command:none";
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
@@ -5,7 +5,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 /**
  * Configuration for the Gogo SSH interface.
  */
-@ObjectClassDefinition
+@ObjectClassDefinition(factoryPid = SshdConfig.PID)
 public @interface SshdConfig  {
 	String	PID				= "biz.aQute.shell.sshd";
 

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
@@ -1,22 +1,25 @@
 package biz.aQute.shell.sshd.config;
 
+import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 /**
  * Configuration for the Gogo SSH interface in an insecure mode.
  */
-@ObjectClassDefinition(factoryPid = SshdConfigInsecure.PID)
+@ObjectClassDefinition(factoryPid = SshdConfigInsecure.PID, description = "Configuration for the Gogo SSH interface in an insecure mode.")
 public @interface SshdConfigInsecure {
 	String PID = "biz.aQute.shell.sshd.insecure";
 
 	/**
 	 * The port to run on, by default this is {@value}
 	 */
+	@AttributeDefinition(description = "The port to run on")
 	int port() default 8061;
 
 	/**
 	 * Where to store the private key. This must be in forward slashes. Default is
-	 * 'host.ser' in the bundle's directory
+	 * 'target/host.ser' in the bundle's directory
 	 */
+	@AttributeDefinition(description = "Where to store the private key. This must be in forward slashes.")
 	String hostkey() default "target/host.ser";
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
@@ -5,9 +5,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 /**
  * Configuration for the Gogo SSH interface in an insecure mode.
  */
-@ObjectClassDefinition
+@ObjectClassDefinition(factoryPid = SshdConfigInsecure.PID)
 public @interface SshdConfigInsecure {
-	String	PID	= "biz.aQute.shell.sshd.insecure";
+	String PID = "biz.aQute.shell.sshd.insecure";
 
 	/**
 	 * The port to run on, by default this is {@value}
@@ -15,8 +15,8 @@ public @interface SshdConfigInsecure {
 	int port() default 8061;
 
 	/**
-	 * Where to store the private key. This must be in forward slashes. Default
-	 * is 'host.ser' in the bundle's directory
+	 * Where to store the private key. This must be in forward slashes. Default is
+	 * 'host.ser' in the bundle's directory
 	 */
 	String hostkey() default "target/host.ser";
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
@@ -20,15 +20,16 @@ import org.slf4j.LoggerFactory;
 import aQute.lib.io.IO;
 
 abstract class AbstractGogoSshd {
-	final static Logger		logger	= LoggerFactory.getLogger("GogoSshd");
+	final static Logger logger = LoggerFactory.getLogger("GogoSshd");
 
-	final SshServer			sshd;
-	final CommandProcessor	processor;
-	final BundleContext		context;
-	
-	volatile int			port;
+	final SshServer sshd;
+	final CommandProcessor processor;
+	final BundleContext context;
 
-	AbstractGogoSshd(BundleContext context, CommandProcessor processor, String keypath, String host, int port) throws IOException {
+	volatile int port;
+
+	AbstractGogoSshd(BundleContext context, CommandProcessor processor, String keypath, String host, int port)
+			throws IOException {
 		this.context = context;
 		this.processor = processor;
 		this.sshd = SshServer.setUpDefaultServer();
@@ -47,27 +48,23 @@ abstract class AbstractGogoSshd {
 	void open() throws IOException {
 		sshd.start();
 		port = sshd.getPort();
-		System.out.println(sshd);
-	}
-
-	void close() throws IOException {
-		sshd.stop(true);
+		logger.info("SshServer opened: %s", sshd.toString());
 	}
 
 	private Command getCommand(CommandProcessor processor) {
 
 		return new Command() {
 
-			OutputStream			out;
-			OutputStream			err;
-			InputStream				in;
-			ExitCallback			callback;
-			CommandSessionHandler	session;
+			OutputStream out;
+			OutputStream err;
+			InputStream in;
+			ExitCallback callback;
+			CommandSessionHandler session;
 
 			@Override
 			public void start(ChannelSession channel, Environment env) throws IOException {
 				try {
-					session = getCommandSessionHandler(context, channel,env, in, out, err, processor, callback);
+					session = getCommandSessionHandler(context, channel, env, in, out, err, processor, callback);
 				} catch (Exception e) {
 					logger.error("failed to create a session {}", e, e);
 					throw new RuntimeException(e);
@@ -102,13 +99,14 @@ abstract class AbstractGogoSshd {
 		};
 	}
 
-	@Deactivate
+
 	void deactivate() throws IOException {
-		sshd.stop();
+		sshd.stop(true);
 		sshd.close();
 	}
 
-	protected abstract CommandSessionHandler getCommandSessionHandler(BundleContext context, ChannelSession channel, Environment env,
-			InputStream in, OutputStream out, OutputStream err, CommandProcessor processor2, ExitCallback callback) throws Exception;
+	protected abstract CommandSessionHandler getCommandSessionHandler(BundleContext context, ChannelSession channel,
+			Environment env, InputStream in, OutputStream out, OutputStream err, CommandProcessor processor2,
+			ExitCallback callback) throws Exception;
 
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
@@ -13,14 +13,13 @@ import org.apache.sshd.server.channel.ChannelSession;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
 import biz.aQute.shell.sshd.config.SshdConfigInsecure;
 
 @Designate(ocd = SshdConfigInsecure.class, factory = true)
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = SshdConfigInsecure.PID)
+@Component
 public class GogoSshdInsecure extends AbstractGogoSshd {
 
 	@Activate

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
@@ -13,6 +13,7 @@ import org.apache.sshd.server.channel.ChannelSession;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
@@ -25,7 +26,7 @@ public class GogoSshdInsecure extends AbstractGogoSshd {
 	@Activate
 	public GogoSshdInsecure(BundleContext context, @Reference CommandProcessor processor, SshdConfigInsecure config)
 			throws IOException {
-		super(context,processor, config.hostkey(), "localhost", config.port());
+		super(context, processor, config.hostkey(), "localhost", config.port());
 		logger.warn("starting insecure ssh server on port localhost:{}", config.port());
 
 		sshd.setPasswordAuthenticator(AcceptAllPasswordAuthenticator.INSTANCE);
@@ -34,8 +35,15 @@ public class GogoSshdInsecure extends AbstractGogoSshd {
 	}
 
 	@Override
-	protected CommandSessionHandler getCommandSessionHandler(BundleContext context, ChannelSession channel, Environment env, InputStream in,
-			OutputStream out, OutputStream err, CommandProcessor processor, ExitCallback callback) throws Exception {
-		return new CommandSessionHandler(context,channel, env, in, out, err, processor, callback);
+	protected CommandSessionHandler getCommandSessionHandler(BundleContext context, ChannelSession channel,
+			Environment env, InputStream in, OutputStream out, OutputStream err, CommandProcessor processor,
+			ExitCallback callback) throws Exception {
+		return new CommandSessionHandler(context, channel, env, in, out, err, processor, callback);
 	}
+
+	@Deactivate
+	void deactivate() throws IOException {
+		super.deactivate();
+	}
+
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
@@ -18,7 +18,6 @@ import org.apache.sshd.server.session.ServerSession;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.Designate;
 
@@ -29,7 +28,7 @@ import biz.aQute.authorization.api.AuthorityAdmin;
 import biz.aQute.shell.sshd.config.SshdConfig;
 
 @Designate(ocd = SshdConfig.class, factory=true)
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = SshdConfig.PID)
+@Component
 public class GogoSshdSecure extends AbstractGogoSshd {
 
 	final Authenticator					authenticator;


### PR DESCRIPTION
- when `@Designate(factory=true)` by default it means `@Component(configurationPolicy = ConfigurationPolicy.REQUIRE`
- when `@Designate(ocd = SshdConfig.class)` you do not need  `@Component(configurationPid = SshdConfig.PID)` because it takes the Pid from the Designated class `@ObjectClassDefinition(factoryPid = SshdConfig.PID)`
- bnd does not look for `@Deactivate` in superclasses
- Removed unused close-Method of ` AbstractGogoSshd.java`
- Add Metatype Annotations for better doc 