### PR TITLE
Config-PID must be set on Component

### DIFF
--- a/biz.aQute.api/src/main/java/biz/aQute/authentication/api/AuthenticationConstants.java
+++ b/biz.aQute.api/src/main/java/biz/aQute/authentication/api/AuthenticationConstants.java
@@ -7,7 +7,7 @@ public interface AuthenticationConstants {
 	/**
 	 * Name
 	 */
-	String	AUTHENTICATION_SPECIFICATION_NAME		= "osgi.enroute.authenticator";
+	String	AUTHENTICATION_SPECIFICATION_NAME		= "biz.aQute.authenticator";
 	/**
 	 * Version
 	 */

--- a/biz.aQute.authenticator.useradmin.provider/src/main/java/biz/aQute/authenticator/useradmin/provider/Config.java
+++ b/biz.aQute.authenticator.useradmin.provider/src/main/java/biz/aQute/authenticator/useradmin/provider/Config.java
@@ -1,5 +1,7 @@
 package biz.aQute.authenticator.useradmin.provider;
 
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition
@@ -8,13 +10,12 @@ public @interface Config {
 		PBKDF2WithHmacSHA1
 	}
 
-	byte[] salt() default {
-		0x2f, 0x68, (byte) 0xcb, 0x75, 0x6c, (byte) 0xf1, 0x74, (byte) 0x84, 0x2a, (byte) 0xef
-	};
+	byte[] salt() default { 0x2f, 0x68, (byte) 0xcb, 0x75, 0x6c, (byte) 0xf1, 0x74, (byte) 0x84, 0x2a, (byte) 0xef };
 
 	int iterations() default 997;
 
 	Algorithm algorithm() default Algorithm.PBKDF2WithHmacSHA1;
 
+	@AttributeDefinition(type = AttributeType.PASSWORD, description = "If set, the hashed password of user must equal this value.")
 	String _root() default "";
 }

--- a/biz.aQute.authenticator.useradmin.provider/src/main/java/biz/aQute/authenticator/useradmin/provider/UserAdminAuthenticator.java
+++ b/biz.aQute.authenticator.useradmin.provider/src/main/java/biz/aQute/authenticator/useradmin/provider/UserAdminAuthenticator.java
@@ -17,6 +17,7 @@ import org.osgi.namespace.implementation.ImplementationNamespace;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.useradmin.Role;
 import org.osgi.service.useradmin.User;
 import org.osgi.service.useradmin.UserAdmin;
@@ -34,6 +35,7 @@ import biz.aQute.authenticator.useradmin.provider.Config.Algorithm;
 		"hash", "passwd", "adduser", "rmrole", "role", "user"
 })
 @Component
+@Designate(ocd = Config.class)
 public class UserAdminAuthenticator implements Authenticator {
 	private static Logger			log				= LoggerFactory.getLogger(UserAdminAuthenticator.class);
 	private static final Pattern	AUTHORIZATION_P	= Pattern.compile("Basic\\s+(?<base64>[A-Za-z0-9+/]{3,}={0,2})");

--- a/biz.aQute.shell.sshd.provider/bnd.bnd
+++ b/biz.aQute.shell.sshd.provider/bnd.bnd
@@ -34,6 +34,8 @@ Bundle-Description: \
 	org.mockito.mockito-all,\
 	org.awaitility
 
+-dsannotations-options: inherit
+
 -conditionalpackage: org.apache.sshd.*, aQute.lib*
 
 DynamicImport-Package: \

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfig.java
@@ -6,7 +6,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 /**
  * Configuration for the Gogo SSH interface.
  */
-@ObjectClassDefinition(factoryPid = SshdConfig.PID, description = "Configuration for the Gogo SSH interface.")
+@ObjectClassDefinition( description = "Configuration for the Gogo SSH interface.")
 public @interface SshdConfig {
 	String PID = "biz.aQute.shell.sshd";
 

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
@@ -6,7 +6,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 /**
  * Configuration for the Gogo SSH interface in an insecure mode.
  */
-@ObjectClassDefinition(factoryPid = SshdConfigInsecure.PID, description = "Configuration for the Gogo SSH interface in an insecure mode.")
+@ObjectClassDefinition(description = "Configuration for the Gogo SSH interface in an insecure mode.")
 public @interface SshdConfigInsecure {
 	String PID = "biz.aQute.shell.sshd.insecure";
 

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
@@ -13,6 +13,7 @@ import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ abstract class AbstractGogoSshd {
 		};
 	}
 
-
+	@Deactivate
 	void deactivate() throws IOException {
 		sshd.stop(true);
 		sshd.close();

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/AbstractGogoSshd.java
@@ -13,7 +13,6 @@ import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
@@ -41,9 +41,4 @@ public class GogoSshdInsecure extends AbstractGogoSshd {
 		return new CommandSessionHandler(context, channel, env, in, out, err, processor, callback);
 	}
 
-	@Deactivate
-	void deactivate() throws IOException {
-		super.deactivate();
-	}
-
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdInsecure.java
@@ -20,7 +20,7 @@ import org.osgi.service.metatype.annotations.Designate;
 import biz.aQute.shell.sshd.config.SshdConfigInsecure;
 
 @Designate(ocd = SshdConfigInsecure.class, factory = true)
-@Component
+@Component(configurationPid = SshdConfigInsecure.PID )
 public class GogoSshdInsecure extends AbstractGogoSshd {
 
 	@Activate

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
@@ -29,7 +29,7 @@ import biz.aQute.authorization.api.AuthorityAdmin;
 import biz.aQute.shell.sshd.config.SshdConfig;
 
 @Designate(ocd = SshdConfig.class, factory = true)
-@Component
+@Component(configurationPid = SshdConfig.PID )
 public class GogoSshdSecure extends AbstractGogoSshd {
 
 	final Authenticator authenticator;

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/provider/GogoSshdSecure.java
@@ -112,9 +112,4 @@ public class GogoSshdSecure extends AbstractGogoSshd {
 		return true;
 	}
 
-	@Deactivate
-	void deactivate() throws IOException {
-		super.deactivate();
-	}
-
 }


### PR DESCRIPTION
Sorry, one of my changes was wrong! 
-Configuration-PID must be set on Component. 

We also can force bnd to search annotations in superclass using `-dsannotations-options: inherit`