### PR TITLE
secure password - do not show as service-property

### DIFF
--- a/biz.aQute.kibana/src/main/java/biz/aQute/kibana/KibanaLogUploader.java
+++ b/biz.aQute.kibana/src/main/java/biz/aQute/kibana/KibanaLogUploader.java
@@ -22,6 +22,7 @@ import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogLevel;
 import org.osgi.service.log.LogReaderService;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
@@ -41,7 +42,12 @@ public class KibanaLogUploader extends Thread {
 		@AttributeDefinition(required = true, description = "List of URIs to the Elastic search host. This is the scheme + host + port. The path is discarded")
 		String[] hosts();
 
-		@AttributeDefinition(required = true, description = "Password for Elastic search")
+		/**
+		 * This name starts with full stop. Is is available to the component
+		 * instance but not available as service properties of the registered
+		 * service.
+		 */
+		@AttributeDefinition(required = true, description = "Password for Elastic search", name = ".password", type = AttributeType.PASSWORD)
 		String password();
 
 		@AttributeDefinition(required = true, description = "User id for Elastic search")

--- a/biz.aQute.mqtt.paho.client/src/main/java/biz/aQute/mqtt/paho/client/config/BrokerConfig.java
+++ b/biz.aQute.mqtt.paho.client/src/main/java/biz/aQute/mqtt/paho/client/config/BrokerConfig.java
@@ -1,5 +1,7 @@
 package biz.aQute.mqtt.paho.client.config;
 
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition
@@ -9,6 +11,11 @@ public @interface BrokerConfig {
 	String name();
 	
 	String username();
+
+	/**
+	 * This name starts with full stop. Is is available to the component instance but not available as service properties of the registered service. 
+	 */
+	@AttributeDefinition(name = ".password", type = AttributeType.PASSWORD)
 	String password();
 
 }

--- a/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
+++ b/biz.aQute.shell.sshd.provider/src/main/java/biz/aQute/shell/sshd/config/SshdConfigInsecure.java
@@ -32,7 +32,8 @@ public @interface SshdConfigInsecure {
 	
 	/**
 	 * The only accepted user name. THIS IS NOT SECURE!
+	 * This name starts with full stop. Is is available to the component instance but not available as service properties of the registered service. 
 	 */
-	@AttributeDefinition(type = AttributeType.PASSWORD,description = "The only accepted password")
+	@AttributeDefinition(name = ".password", type = AttributeType.PASSWORD, description = "The only accepted password. THIS IS NOT SECURE!")
 	String password() default "insecure";
 }


### PR DESCRIPTION
to secure some serviceProperties wi should secure them using  names starting with a full stop `(.)`.

so you prefere to set the name using the AttributeDefinition

```
	@AttributeDefinition(name = ".password", type = AttributeType.PASSWORD)
	String password();
```

or starting the method with a `_`

```
	@AttributeDefinition(type = AttributeType.PASSWORD)
	String _password();
```

... cant see why the tests fail